### PR TITLE
[SYNTH-13711] Make Xcode step run on a Xcode stack

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -95,7 +95,7 @@ workflows:
             set -ex
             pwd
             ls -la
-    - path::./:
+    - path::./Users/vagrant/git:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -113,7 +113,7 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - path::./:
+    - path::./Users/vagrant/git:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -88,13 +88,6 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            pwd
-            ls -la
     - path::./Users/vagrant/git:
         title: Upload Android application
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,13 +39,6 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            pwd
-            ls -la
     - path::./:
         title: Upload Android application
         inputs:
@@ -95,6 +88,13 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            pwd
+            ls -la
     - path::./:
         title: Upload Android application
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -100,7 +100,7 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/bitrise/src/example-app.apk"
+        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.apk"
         - mobile_application_id: "7b54b434-59ea-4ef7-868b-12c9180842f7"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
@@ -118,7 +118,7 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/bitrise/src/example-app.ipa"
+        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.ipa"
         - mobile_application_id: "bcb5d107-5536-4fe5-a4a8-ea34a6c9bbee"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,6 +39,13 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            pwd
+            ls -la
     - path::./:
         title: Upload Android application
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,7 +93,7 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.apk"
+        - mobile_application_version_file_path: "/bitrise/src/git/example-app.apk"
         - mobile_application_id: "7b54b434-59ea-4ef7-868b-12c9180842f7"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
@@ -111,7 +111,7 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.ipa"
+        - mobile_application_version_file_path: "/bitrise/src/git/example-app.ipa"
         - mobile_application_id: "bcb5d107-5536-4fe5-a4a8-ea34a6c9bbee"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -88,12 +88,12 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - path::./Users/vagrant/git:
+    - path::/Users/vagrant/git:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/bitrise/src/git/example-app.apk"
+        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.apk"
         - mobile_application_id: "7b54b434-59ea-4ef7-868b-12c9180842f7"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
@@ -106,12 +106,12 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - path::./Users/vagrant/git:
+    - path::/Users/vagrant/git:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/bitrise/src/git/example-app.ipa"
+        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.ipa"
         - mobile_application_id: "bcb5d107-5536-4fe5-a4a8-ea34a6c9bbee"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -77,6 +77,10 @@ workflows:
         - fail_on_critical_errors: true
 
   test-on-Xcode-stack:
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2-m1.4core
     steps:
     - script:
         title: Generate version name from timestamp
@@ -124,10 +128,6 @@ workflows:
         - public_ids: "bcq-y54-rq7"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    meta:
-      bitrise.io:
-        stack: osx-xcode-edge
-        machine_type_id: g2-m1.4core
 
 
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,6 +21,10 @@ stages:
     - test-on-Ubuntu-stack: {}
     - test-on-Xcode-stack: {}
 
+meta:
+  bitrise.io:
+    stack: linux-docker-android-22.04
+    machine_type_id: standard
 
 workflows:
   test-on-Ubuntu-stack:
@@ -120,6 +124,10 @@ workflows:
         - public_ids: "bcq-y54-rq7"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
+    meta:
+      bitrise.io:
+        stack: osx-xcode-edge
+        machine_type_id: g2-m1.4core
 
 
 

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -44,6 +44,8 @@ UploadApplication() {
         $DATADOG_CI_COMMAND synthetics upload-application \
         "${args[@]}")
 
+    echo "exit code: $?"
+    
     echo $output
 
     if [[ $output =~ ([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$ ]]; then
@@ -53,6 +55,8 @@ UploadApplication() {
     else
         echo "No Version ID found in the output."
     fi
+
+    echo "exit code: $?"
 }
 
 # Will not run if sourced for bats-core tests.

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -44,8 +44,8 @@ UploadApplication() {
         $DATADOG_CI_COMMAND synthetics upload-application \
         "${args[@]}")
 
-    echo "exit code: $?"
     command_exit_code=$?
+    echo "exit code: $?"
     
     echo $output
 

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -45,8 +45,6 @@ UploadApplication() {
         "${args[@]}")
 
     command_exit_code=$?
-    echo "exit code: $?"
-    
     echo $output
 
     if [[ $output =~ ([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$ ]]; then
@@ -57,8 +55,6 @@ UploadApplication() {
         echo "No Version ID found in the output."
     fi
 
-    echo "exit code: $?"
-    echo "Command exit code: $command_exit_code"
     exit $command_exit_code
 }
 

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -58,6 +58,7 @@ UploadApplication() {
     fi
 
     echo "exit code: $?"
+    echo "Command exit code: $command_exit_code"
     exit $command_exit_code
 }
 

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -1,5 +1,3 @@
-echo "Running upload-application.sh"
-
 UploadApplication() {
     if [[ -n "${DD_SITE}" ]]; then
         site=${DD_SITE}
@@ -9,11 +7,9 @@ UploadApplication() {
 
     unamestr=$(uname)
 
-    echo "Downloading datadog-ci version ${DATADOG_CI_VERSION} for ${unamestr}"
     # Not run when running unit tests.
     if [[ -z "${DATADOG_CI_COMMAND}" ]]; then
         if [[ "$unamestr" == 'Darwin' ]]; then
-            echo "Downloading datadog-ci for macOS"
             curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_darwin-x64" --output "./datadog-ci"
         elif [[ "$unamestr" == 'Linux' ]]; then
             curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
@@ -40,7 +36,6 @@ UploadApplication() {
         args+=(--latest)
     fi
 
-    echo "Uploading application with args: ${args[@]}"
     output=$(DATADOG_API_KEY="${api_key}" \
     DATADOG_APP_KEY="${app_key}" \
     DATADOG_SUBDOMAIN="app" \

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -45,6 +45,7 @@ UploadApplication() {
         "${args[@]}")
 
     echo "exit code: $?"
+    command_exit_code=$?
     
     echo $output
 
@@ -57,6 +58,7 @@ UploadApplication() {
     fi
 
     echo "exit code: $?"
+    exit $command_exit_code
 }
 
 # Will not run if sourced for bats-core tests.

--- a/upload-application.sh
+++ b/upload-application.sh
@@ -1,3 +1,5 @@
+echo "Running upload-application.sh"
+
 UploadApplication() {
     if [[ -n "${DD_SITE}" ]]; then
         site=${DD_SITE}
@@ -7,9 +9,11 @@ UploadApplication() {
 
     unamestr=$(uname)
 
+    echo "Downloading datadog-ci version ${DATADOG_CI_VERSION} for ${unamestr}"
     # Not run when running unit tests.
     if [[ -z "${DATADOG_CI_COMMAND}" ]]; then
         if [[ "$unamestr" == 'Darwin' ]]; then
+            echo "Downloading datadog-ci for macOS"
             curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_darwin-x64" --output "./datadog-ci"
         elif [[ "$unamestr" == 'Linux' ]]; then
             curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
@@ -36,6 +40,7 @@ UploadApplication() {
         args+=(--latest)
     fi
 
+    echo "Uploading application with args: ${args[@]}"
     output=$(DATADOG_API_KEY="${api_key}" \
     DATADOG_APP_KEY="${app_key}" \
     DATADOG_SUBDOMAIN="app" \


### PR DESCRIPTION
This PR will make the workflow called `test-on-Xcode-stack` actually run on an Xcode stack in Bitrise instead of the default Ubuntu one 

<img width="1004" alt="image" src="https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/assets/25252536/30b79a28-2ba0-4a0e-99f5-e40fd86227f8">
