### PR TITLE
[SYNTH-15152] Change to using git link to reference step 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To get started:
 1. Add the following git URL to your workflow. See the [official Bitrise documentation][3] on how to do that though the Bitrise app. You can also configure it locally by referencing the git URL in your `bitrise.yml` file.
 
 ```yml
-- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git@1.0.2:
 ```
 
 2. Add your API and application keys to your [secrets in Bitrise][4].
@@ -50,7 +50,7 @@ envs:
 This task overrides the path to the global `datadog-ci.config.json` file.
 
 ```yml
-- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git@1.0.2:
    inputs:
    - api_key: <DATADOG_API_KEY>
    - app_key: <DATADOG_APP_KEY>
@@ -64,7 +64,7 @@ For an example configuration file, see the [`global.config.json` file][7].
 For reference, this is an example of a complete configuration:
 
 ```yml
-- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git@1.0.2:
    inputs:
    - api_key: <DATADOG_API_KEY>
    - app_key: <DATADOG_APP_KEY>

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ With the `synthetics-test-automation-bitrise-step-upload-application` step, you 
 
 ## Setup
 
-This step is not available on the official Bitrise Step Library
+This step is not available on the official Bitrise Step Library.
 To get started:
 
-1. Add the following git URL to your workflow, see the [official Bitrise documentation][3] to see how to do this though the Bitrise app. You can also configure it locally by referencing the git URL in your `bitrise.yml` file.
-```
+1. Add the following git URL to your workflow, see the [official Bitrise documentation][3] to see how to do that though the Bitrise app. You can also configure it locally by referencing the git URL in your `bitrise.yml` file.
+
+```yml
 - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
 ```
+
 2. Add your API and application keys to your [secrets in Bitrise][4].
 3. [Configure your step inputs][5]. You can also configure them in your `bitrise.yml` file. The only required inputs are the two secrets you configured earlier. For a comprehensive list of inputs, see the [Inputs section](#inputs).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ With the `synthetics-test-automation-bitrise-step-upload-application` step, you 
 This step is not available on the official Bitrise Step Library.
 To get started:
 
-1. Add the following git URL to your workflow, see the [official Bitrise documentation][3] to see how to do that though the Bitrise app. You can also configure it locally by referencing the git URL in your `bitrise.yml` file.
+1. Add the following git URL to your workflow. See the [official Bitrise documentation][3] on how to do that though the Bitrise app. You can also configure it locally by referencing the git URL in your `bitrise.yml` file.
 
 ```yml
 - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@
 
 ## Overview
 
-With the [`synthetics-test-automation-bitrise-step-upload-application` step][1], you can upload a new version of your application to Datadog to run Synthetic tests against during your Bitrise CI, ensuring that all your teams using Bitrise can benefit from Synthetic tests at every stage of the software lifecycle. This step uses the [Datadog CI Synthetics command][2], and requires that your application already exists.
+With the `synthetics-test-automation-bitrise-step-upload-application` step, you can upload a new version of your application to Datadog to run Synthetic tests against during your Bitrise CI, ensuring that all your teams using Bitrise can benefit from Synthetic tests at every stage of the software lifecycle. This step uses the [Datadog CI Synthetics command][2], and requires that your application already exists.
 
 ## Setup
 
+This step is not available on the official Bitrise Step Library
 To get started:
 
-1. Add this step to your workflow. You can also configure it locally by referencing this step in your `bitrise.yml` file. For more information, see the [official Bitrise documentation][3].
+1. Add the following git URL to your workflow, see the [official Bitrise documentation][3] to see how to do this though the Bitrise app. You can also configure it locally by referencing the git URL in your `bitrise.yml` file.
+```
+- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+```
 2. Add your API and application keys to your [secrets in Bitrise][4].
 3. [Configure your step inputs][5]. You can also configure them in your `bitrise.yml` file. The only required inputs are the two secrets you configured earlier. For a comprehensive list of inputs, see the [Inputs section](#inputs).
 
@@ -41,11 +45,10 @@ envs:
 
 ### Example task using a global configuration override with `configPath`
 
-<!-- TODO: change git urls to step references after we publish it -->
 This task overrides the path to the global `datadog-ci.config.json` file.
 
 ```yml
-- datadog-mobile-app-upload@1:
+- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
    inputs:
    - api_key: <DATADOG_API_KEY>
    - app_key: <DATADOG_APP_KEY>
@@ -59,7 +62,7 @@ For an example configuration file, see the [`global.config.json` file][7].
 For reference, this is an example of a complete configuration:
 
 ```yml
-- datadog-mobile-app-upload@1:
+- git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
    inputs:
    - api_key: <DATADOG_API_KEY>
    - app_key: <DATADOG_APP_KEY>
@@ -101,7 +104,7 @@ Additional helpful documentation, links, and articles:
 <!-- Links to Marketplace -->
 [1]: https://bitrise.io/integrations/steps/datadog-mobile-app-upload
 [2]: https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration/?tab=npm#run-tests
-[3]: https://devcenter.bitrise.io/en/steps-and-workflows/introduction-to-steps/adding-steps-to-a-workflow.html
+[3]: https://devcenter.bitrise.io/en/steps-and-workflows/introduction-to-steps/adding-steps-to-a-workflow.html#adding-steps-from-alternative-sources
 [4]: https://devcenter.bitrise.io/en/builds/secrets.html#setting-a-secret
 [5]: https://devcenter.bitrise.io/en/steps-and-workflows/introduction-to-steps/step-inputs.html
 [6]: https://github.com/bitrise-io/bitrise

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -49,16 +49,6 @@ workflows:
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
-    - script:
-        title: Look around
-        is_always_run: true
-        inputs:
-        - content: |-
-            #!/bin/bash
-            pwd
-            ls -lha
-            cd  datadog-ci
-            ls -lha
     - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests.git:
         title: Run Android tests
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -57,6 +57,8 @@ workflows:
             #!/bin/bash
             pwd
             ls -lha
+            cd  datadog-ci
+            ls -lha
     - datadog-mobile-app-run-tests@1:
         title: Run Android tests
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,7 +39,7 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+    - path::./:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -57,7 +57,7 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+    - path::./:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -92,7 +92,7 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+    - path::./:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -110,7 +110,7 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
+    - path::./:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -59,7 +59,7 @@ workflows:
             ls -lha
             cd  datadog-ci
             ls -lha
-    - datadog-mobile-app-run-tests@1:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests.git:
         title: Run Android tests
         inputs:
         - api_key: $DATADOG_API_KEY

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,9 +37,9 @@ workflows:
             export APPLICATION_VERSION_NAME="$(date +%s)"
             echo "Generated version_name: $APPLICATION_VERSION_NAME"
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
-    - activate-ssh-key@4: {}
-    - git-clone@8: {}
-    - path::./:
+    # - activate-ssh-key@4: {}
+    # - git-clone@8: {}
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -49,6 +49,13 @@ workflows:
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
+    - script:
+      title: Look around
+      inputs:
+      - content: |-
+          #!/bin/bash
+          pwd
+          ls -lha
     - datadog-mobile-app-run-tests@1:
         title: Run Android tests
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,6 +51,7 @@ workflows:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
     - script:
         title: Look around
+        is_always_run: true
         inputs:
         - content: |-
             #!/bin/bash

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,8 +37,8 @@ workflows:
             export APPLICATION_VERSION_NAME="$(date +%s)"
             echo "Generated version_name: $APPLICATION_VERSION_NAME"
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
-    # - activate-ssh-key@4: {}
-    # - git-clone@8: {}
+    - activate-ssh-key@4: {}
+    - git-clone@8: {}
     - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
         title: Upload Android application
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -92,7 +92,7 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - path::./:
+    - path::/Users/vagrant/git:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -110,7 +110,7 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - path::./:
+    - path::/Users/vagrant/git:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -67,7 +67,7 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - path::./:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -77,7 +77,7 @@ workflows:
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
-    - datadog-mobile-app-run-tests@1:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests.git:
         title: Run iOS tests
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -102,7 +102,7 @@ workflows:
             envman add --key APPLICATION_VERSION_NAME --value "$APPLICATION_VERSION_NAME"
     - activate-ssh-key@4: {}
     - git-clone@8: {}
-    - path::/Users/vagrant/git:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
         title: Upload Android application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -112,7 +112,7 @@ workflows:
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
-    - datadog-mobile-app-run-tests@1:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests.git:
         title: Run Android tests
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -120,7 +120,7 @@ workflows:
         - public_ids: "rxd-vdv-qce"
         - mobile_application_version: $DATADOG_UPLOADED_APPLICATION_VERSION_ID
         - fail_on_critical_errors: true
-    - path::/Users/vagrant/git:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application.git:
         title: Upload iOS application
         inputs:
         - api_key: $DATADOG_API_KEY
@@ -130,7 +130,7 @@ workflows:
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
-    - datadog-mobile-app-run-tests@1:
+    - git::https://github.com/DataDog/synthetics-test-automation-bitrise-step-run-tests.git:
         title: Run iOS tests
         inputs:
         - api_key: $DATADOG_API_KEY

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -50,12 +50,12 @@ workflows:
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
     - script:
-      title: Look around
-      inputs:
-      - content: |-
-          #!/bin/bash
-          pwd
-          ls -lha
+        title: Look around
+        inputs:
+        - content: |-
+            #!/bin/bash
+            pwd
+            ls -lha
     - datadog-mobile-app-run-tests@1:
         title: Run Android tests
         inputs:


### PR DESCRIPTION
We will be taking our step off the official Bitrise step list, so we're updating out documentation and having our own step also reference it by git url