### PR TITLE
[SYNTH-11930] Update the release automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.MD
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.MD
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe what happened**
+Include any error message or stack trace if available.
+
+**Steps to reproduce the issue:**
+📝
+
+**Expected behaviour:**
+📝
+
+**Actual behaviour:**
+📝
+
+**Additional context**
+
+- Agent type and version
+- Extension and task version
+- An explanation of what might cause the bug and/or how it can be fixed

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.MD
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.MD
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea or request a feature
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe:**
+📝 A clear and concise description of what the problem is.
+
+**Describe the solution you'd like:**
+📝 A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered:**
+📝 A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context:**
+📝 Add any other context or screenshots about the feature request here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -3,16 +3,16 @@
 name: Bump Datadog CI
 
 env:
-  GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
-  GIT_AUTHOR_NAME: "ci.datadog-ci"
+  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
+  GIT_AUTHOR_NAME: 'ci.datadog-ci'
 
 on:
   workflow_dispatch:
     inputs:
       datadog_ci_version:
-        description: "Version of datadog-ci to install (`latest` or `major.minor.patch`)"
+        description: 'Version of datadog-ci to install (`latest` or `major.minor.patch`)'
         type: string
-        default: "latest"
+        default: 'latest'
 
 jobs:
   bump-datadog-ci:

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -74,7 +74,7 @@ jobs:
           script: |
             const body = `This PR was automatically created because a new version of datadog-ci was published.
 
-            In case the ci/bitrise check is failing, please go to the `Details` and then click `Rebuild` and rebuild the unsuccessful workflows.
+            In case the Bitrise CI check is failing, please follow the "Details" link in GitHub and then, in Bitrise, click "Rebuild" and choose "Rebuild unsuccessful Workflows".
 
             > [!IMPORTANT]
             > **You are not done!**

--- a/.github/workflows/bump-datadog-ci.yml
+++ b/.github/workflows/bump-datadog-ci.yml
@@ -3,16 +3,16 @@
 name: Bump Datadog CI
 
 env:
-  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
-  GIT_AUTHOR_NAME: 'ci.datadog-ci'
+  GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
+  GIT_AUTHOR_NAME: "ci.datadog-ci"
 
 on:
   workflow_dispatch:
     inputs:
       datadog_ci_version:
-        description: 'Version of datadog-ci to install (`latest` or `major.minor.patch`)'
+        description: "Version of datadog-ci to install (`latest` or `major.minor.patch`)"
         type: string
-        default: 'latest'
+        default: "latest"
 
 jobs:
   bump-datadog-ci:
@@ -73,6 +73,8 @@ jobs:
           github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const body = `This PR was automatically created because a new version of datadog-ci was published.
+
+            In case the ci/bitrise check is failing, please go to the `Details` and then click `Rebuild` and rebuild the unsuccessful workflows.
 
             > [!IMPORTANT]
             > **You are not done!**

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -3,20 +3,20 @@
 name: Create Release PR
 
 env:
-  GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
-  GIT_AUTHOR_NAME: "ci.datadog-ci"
+  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
+  GIT_AUTHOR_NAME: 'ci.datadog-ci'
 
 on:
   workflow_dispatch:
     inputs:
       semver:
-        description: "Semver argument for the version bump to do on the CI integration"
-        default: "minor"
+        description: 'Semver argument for the version bump to do on the CI integration'
+        default: 'minor'
         type: choice
         options:
-          - "patch"
-          - "minor"
-          - "major"
+          - 'patch'
+          - 'minor'
+          - 'major'
 
 jobs:
   create-release-pr:

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -3,20 +3,20 @@
 name: Create Release PR
 
 env:
-  GIT_AUTHOR_EMAIL: 'packages@datadoghq.com'
-  GIT_AUTHOR_NAME: 'ci.datadog-ci'
+  GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
+  GIT_AUTHOR_NAME: "ci.datadog-ci"
 
 on:
   workflow_dispatch:
     inputs:
       semver:
-        description: 'Semver argument for the version bump to do on the CI integration'
-        default: 'minor'
+        description: "Semver argument for the version bump to do on the CI integration"
+        default: "minor"
         type: choice
         options:
-          - 'patch'
-          - 'minor'
-          - 'major'
+          - "patch"
+          - "minor"
+          - "major"
 
 jobs:
   create-release-pr:
@@ -97,8 +97,7 @@ jobs:
             const body = `Once merged, this PR will automatically create a GitHub release for you.
             The description of the release will exactly match this PR's description. Feel free to edit it.
 
-            > [!WARNING]
-            > You now have to create a PR on https://github.com/bitrise-io/bitrise-steplib via our Datadog fork to officially publish the Bitrise step.
+            We publish the bitrise steps ourselves, so you don't have to do anything else.`
 
             github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -97,7 +97,7 @@ jobs:
             const body = `Once merged, this PR will automatically create a GitHub release for you.
             The description of the release will exactly match this PR's description. Feel free to edit it.
 
-            We publish the bitrise steps ourselves, so you don't have to do anything else.`
+            The new version of the Bitrise step will be available to customers as soon as the GitHub release is published.`
 
             github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+First of all, thanks for contributing!
+
+This document provides some basic guidelines for contributing to this repository. To propose improvements, feel free to submit a pull request.
+
+## Submitting issues
+
+GitHub issues are welcome, feel free to submit error reports and feature requests.
+
+- Ensure the bug was not already reported by searching on GitHub under [Issues][1].
+- If you're unable to find an open issue addressing the problem, [open a new one][2].
+- Make sure to add enough details to explain your use case.
+
+If you require further assistance, contact [Datadog Support][3].
+
+## Submitting pull requests
+
+Have you fixed a bug or wrote a new feature and want to share it? Thanks!
+
+To expedite your pull request's review, follow these best practices when submitting your pull request:
+
+- **Write meaningful commit messages**: Messages should be concise and explanatory. The commit message describes the reason for your change, which you can reference later.
+
+- **Keep it small and focused**: Pull requests should contain only one fix or one feature improvement. Bundling several fixes or features in the same PR makes it more difficult to review, and takes longer to release.
+
+- **Write tests for the code you wrote**: Each script should be tested. The tests for a script are located in the [`tests` folder][4], under a file with the same name as the script.
+**Note:** Datadog's internal CI is not publicly available, so if your pull request status is failing, make sure that all tests pass locally. The Datadog team can help you address errors flagged by the CI.
+
+### Publishing
+
+The title of the pull request must contain a special semver tag, `[semver:<segment>]`, where `<segment>` is replaced by one of the following values.
+
+| Increment | Description|
+| ----------| -----------|
+| major     | Issue a 1.0.0 incremented release|
+| minor     | Issue a x.1.0 incremented release|
+| patch     | Issue a x.x.1 incremented release|
+| skip      | Do not issue a release|
+
+Example: `[semver:major]`
+
+* Update the public `CHANGELOG.md` with the release changes.
+* Squash and merge. Ensure the semver tag is preserved and entered as a part of the commit message.
+* On merge, after manual approval, the orb will automatically be published to the Orb Registry.
+
+## Style guide
+
+The code under this repository follows a format enforced by [Prettier][5], and a style guide enforced by [eslint][6].
+
+## Releasing a new version
+
+The integration has workflows set up to automate the release process, by creating commits, PRs, tags and releases.
+
+The PRs created as part of the release process will need to be merged manually and each will contain instructions inside them for what needs to be done.
+
+Whenever a new version of [datadog-ci][7] is released, a new PR will automatically be created on the current repository. The PR will be named `[dep] Bump datadog-ci to {version}` and will contain the changes to update to the latest version of datadog-ci and the steps you need to follow to continue the release process.
+
+After completing the steps from the **[dep]** PR, a new **[release]** PR will automatically be created. When this happens, go to the PR and follow the instructions there on how to finalize the release process.
+
+You can see examples of past releases [here][8].
+
+## Asking questions
+
+Need help? Contact [Datadog support][3].
+
+[1]: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/issues
+[2]: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/issues/new
+[3]: https://docs.datadoghq.com/help/
+[4]: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/tree/main/tests
+[5]: https://prettier.io/
+[6]: https://eslint.org/docs/rules/
+[7]: https://github.com/DataDog/datadog-ci
+[8]: https://github.com/DataDog/synthetics-test-automation-bitrise-step-upload-application/pulls?q=is%3Apr+is%3Aclosed+%28%22%5Bdep%5D+Bump+datadog-ci%22+OR+%22%5Brelease%3Aminor%22%29

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,200 @@
-The MIT License (MIT)
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Copyright (c) 2023 Teodor Todorov
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2022-present Datadog, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,0 +1,15 @@
+@datadog/datadog-ci,import,Apache-2.0,"Copyright 2019-Present Datadog, Inc."
+@types/deep-extend,dev,MIT,Copyright Microsoft Corporation
+@types/jest,dev,MIT,Copyright Microsoft Corporation
+@types/node,dev,MIT,Copyright Microsoft Corporation
+@typescript-eslint/eslint-plugin,dev,BSD 2-Clause License, Copyright JS Foundation and other contributors
+@typescript-eslint/parser,dev,BSD 2-Clause License, Copyright JS Foundation and other contributors
+azure-pipelines-task-lib,import,MIT,Copyright (c) Microsoft Corporation
+deep-extend,import,MIT,"Copyright (c) 2013-2018, Viacheslav Lotsmanov"
+eslint,dev,MIT,Copyright OpenJS Foundation and other contributors
+eslint-plugin-jest,dev,MIT,Copyright (c) 2018 Jonathan Kim
+eslint-plugin-prettier,dev,MIT,Copyright © 2017 Andres Suarez and Teddy Katz
+jest,dev,MIT,"Copyright (c) Facebook, Inc. and its affiliates."
+prettier,dev,MIT,Copyright © James Long and contributors
+ts-jest,dev,MIT,Copyright (c) 2016-2018
+typescript,dev,Apache-2.0,Copyright (c) Microsoft Corporation.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Datadog synthetics-ci-orb
+Copyright 2022-present Datadog, Inc.
+
+This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/ci/increment-version.sh
+++ b/ci/increment-version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+VERSION=$(git describe --abbrev=0 --tags)
+
+MAJOR=$(echo $VERSION | cut -d. -f1 | sed 's/v//') 
+MINOR=$(echo $VERSION | cut -d. -f2)
+PATCH=$(echo $VERSION | cut -d. -f3)
+
+if [ "$1" == "major" ]; then
+  MAJOR=$((MAJOR+1))
+  MINOR=0
+  PATCH=0
+elif [ "$1" == "minor" ]; then
+  MINOR=$((MINOR+1))
+  PATCH=0
+elif [ "$1" == "patch" ]; then
+  PATCH=$((PATCH+1))
+else
+  echo "Invalid version type. Use 'major', 'minor' or 'patch'"
+  exit 1
+fi
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+echo $NEW_VERSION 


### PR DESCRIPTION
We're updating the release automation to be on par with all the other integrations.

* This PR fixes an issue with the create-release-pr job 
* it also changes the descriptions in the generated PRs to reflect the fact that we are self-publishing the Bitrise Steps so after releasing a new version on Github no further actions are needed.
* Also added a CONTRIBUTING.md similarly to the rest of the integrations.
* Updated LICENSE and NOTICE
* Add issue templates
* Add dependabot.yml