### PR TITLE
[docs] Fix property casing, tag references in examples and incorrect `mobile_application_version_id`

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -43,13 +43,12 @@ jobs:
         id: bump-version
         run: |
           OLD_VERSION_TAG=$(git describe --abbrev=0 --tags) # e.g. v1.0.0
-          OLD_VERSION=${OLD_VERSION_TAG/v/}
 
           NEW_VERSION=$(./ci/increment-version.sh ${{ github.event.inputs.semver }})
           NEW_VERSION_TAG="v$NEW_VERSION" # e.g. v1.1.0
 
           # Update README with new version
-          sed -i "s/$OLD_VERSION/$NEW_VERSION/" README.md
+          sed -i "s/$OLD_VERSION_TAG/$NEW_VERSION_TAG/" README.md
 
           echo "NEW_VERSION_TAG=$NEW_VERSION_TAG" >> $GITHUB_OUTPUT
       - name: Commit new version

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For reference, this is an example of a complete configuration:
    - app_key: <DATADOG_APP_KEY>
    - config_path: './global.config.json'
    - latest: true
-   - mobile_application_version_id: '123-123-123'
+   - mobile_application_id: '123-123-123'
    - mobile_application_version_file_path: 'path/to/application.apk'
    - site: 'datadoghq.com'
    - version_name: 'example 1.0'
@@ -84,7 +84,7 @@ For reference, this is an example of a complete configuration:
 | `app_key`                              | _required_  | Your Datadog application key. This key is created by your [Datadog organization][8] and will be accessed as an environment variable.                                                                      |
 | `config_path`                          | _optional_  | The global JSON configuration is used when launching tests. See the [example configuration][9] for more details.                                                                                          |
 | `latest`                               | _optional_  | Marks the application as `latest`. Any tests that run on the latest version will use this version on their next run.                                                                                      |
-| `mobile_application_version_id`        | _required_  | ID of the application you want to upload the new version to.                                                                                                                                              |
+| `mobile_application_id`                | _required_  | ID of the application you want to upload the new version to.                                                                                                                                              |
 | `mobile_application_version_file_path` | _required_  | Override the application version for [Synthetic mobile application tests][15].                                                                                                                            |
 | `site`                                 | _optional_  | The [Datadog site][14] to send data to. <!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->. If the `DD_SITE` environment variable is set, it takes precedence. |
 | `version_name`                         | _required_  | Name of the new version. It has to be unique.                                                                                                                                                             |

--- a/README.md
+++ b/README.md
@@ -78,21 +78,21 @@ For reference, this is an example of a complete configuration:
 
 ## Inputs
 
-| Name                               | Requirement | Description                                                                                                                             |
-| -----------------------------------| :---------: | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiKey`                           | _required_  | Your Datadog API key. This key is created by your [Datadog organization][8] and will be accessed as an environment variable.         |
-| `appKey`                           | _required_  | Your Datadog application key. This key is created by your [Datadog organization][8] and will be accessed as an environment variable. |
-| `configPath`                       | _optional_  | The global JSON configuration is used when launching tests. See the [example configuration][9] for more details.                     |
-| `latest`                           | _optional_  | Marks the application as `latest`. Any tests that run on the latest version will use this version on their next run.                    |
-| `mobileApplicationVersionId`       | _required_  | ID of the application you want to upload the new version to.                                                                            |
-| `mobileApplicationVersionFilePath` | _required_  | Override the application version for [Synthetic mobile application tests][15].                                                                |
-| `site`                             | _optional_  | The [Datadog site][14] to send data to. <!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->. If the `DD_SITE` environment variable is set, it takes precedence.                                    |
-| `versionName`                      | _required_  | Name of the new version. It has to be unique.                                                                                           |
+| Name                                   | Requirement | Description                                                                                                                                                                                               |
+| -------------------------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api_key`                              | _required_  | Your Datadog API key. This key is created by your [Datadog organization][8] and will be accessed as an environment variable.                                                                              |
+| `app_key`                              | _required_  | Your Datadog application key. This key is created by your [Datadog organization][8] and will be accessed as an environment variable.                                                                      |
+| `config_path`                          | _optional_  | The global JSON configuration is used when launching tests. See the [example configuration][9] for more details.                                                                                          |
+| `latest`                               | _optional_  | Marks the application as `latest`. Any tests that run on the latest version will use this version on their next run.                                                                                      |
+| `mobile_application_version_id`        | _required_  | ID of the application you want to upload the new version to.                                                                                                                                              |
+| `mobile_application_version_file_path` | _required_  | Override the application version for [Synthetic mobile application tests][15].                                                                                                                            |
+| `site`                                 | _optional_  | The [Datadog site][14] to send data to. <!-- partial Your Datadog site is {{< region-param key="dd_site" code="true" >}}. partial -->. If the `DD_SITE` environment variable is set, it takes precedence. |
+| `version_name`                         | _required_  | Name of the new version. It has to be unique.                                                                                                                                                             |
 
 ## Outputs
 
-| Name                                      | Description                                                                                                                                                                                               |
-| ------------------------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Name                                      | Description                                                                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `DATADOG_UPLOADED_APPLICATION_VERSION_ID` | The version ID of the application that was just uploaded. Pass it to the [`datadog-mobile-app-run-tests` step][10] with the `mobile_application_version` input to test this version of the application. |
 
 ## Further reading

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -44,8 +44,8 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/bitrise/src/example-app.apk"
         - mobile_application_id: "7b54b434-59ea-4ef7-868b-12c9180842f7"
+        - mobile_application_version_file_path: "/bitrise/src/example-app.apk"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
@@ -62,8 +62,8 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/bitrise/src/example-app.ipa"
         - mobile_application_id: "bcb5d107-5536-4fe5-a4a8-ea34a6c9bbee"
+        - mobile_application_version_file_path: "/bitrise/src/example-app.ipa"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
@@ -97,8 +97,8 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.apk"
         - mobile_application_id: "7b54b434-59ea-4ef7-868b-12c9180842f7"
+        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.apk"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID
@@ -115,8 +115,8 @@ workflows:
         inputs:
         - api_key: $DATADOG_API_KEY
         - app_key: $DATADOG_APP_KEY
-        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.ipa"
         - mobile_application_id: "bcb5d107-5536-4fe5-a4a8-ea34a6c9bbee"
+        - mobile_application_version_file_path: "/Users/vagrant/git/example-app.ipa"
         - version_name: "$APPLICATION_VERSION_NAME"
         outputs:
         - DATADOG_UPLOADED_APPLICATION_VERSION_ID: DATADOG_UPLOADED_APPLICATION_VERSION_ID


### PR DESCRIPTION
This PR fixes incorrect casing in the property table (camelCase instead of snake_case), and tag references in examples (`@A.B.C` instead of `@vA.B.C`).

It also fixes a typo: `mobile_application_version_id` should be `mobile_application_id`